### PR TITLE
Provide interface file for all the types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+const cardIndex = require('./types/choose_options/index');
+const infoIndex = require('./types/info/index');
+const chooseOptionsIndex = require('./types/choose_options/index');
+
+module.exports = {
+  choose_options: {
+    card: cardIndex,
+  },
+  info: {
+    card: infoIndex,
+  },
+  order_items: {
+    card: chooseOptionsIndex,
+  },
+};

--- a/scripts/testCardTypes.js
+++ b/scripts/testCardTypes.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require,import/no-dynamic-require */
 const { lstatSync, readdirSync, writeFileSync } = require('fs');
-const { join } = require('path');
+const { join, sep } = require('path');
 const { tmpdir } = require('os');
 const AnkiExport = require('anki-apkg-export').default;
 
@@ -105,7 +105,7 @@ const testAnkiCardCreation = async typeDir => {
 };
 
 const testPackageInterface = async typeDir => {
-  const type = typeDir.replace('types/', '');
+  const type = typeDir.replace(`types${sep}`, '');
   const interfaceFile = require('../index.js');
   return type in interfaceFile;
 };

--- a/scripts/testCardTypes.js
+++ b/scripts/testCardTypes.js
@@ -104,6 +104,12 @@ const testAnkiCardCreation = async typeDir => {
   return result;
 };
 
+const testPackageInterface = async typeDir => {
+  const type = typeDir.replace('types/', '');
+  const interfaceFile = require('../index.js');
+  return type in interfaceFile;
+};
+
 (async () => {
   await Promise.all(
     currentTypes.filter(filterTypesToCheck).map(async typeDir => {
@@ -130,6 +136,11 @@ const testAnkiCardCreation = async typeDir => {
       const ankiCardCreationResult = await testAnkiCardCreation(typeDir);
       if (!ankiCardCreationResult) {
         errors.push('anki-cards should generate cards from example data');
+      }
+
+      const packageInterfaceResult = await testPackageInterface(typeDir);
+      if (!packageInterfaceResult) {
+        errors.push('type should be presented in module interface file');
       }
 
       if (errors.length) {


### PR DESCRIPTION
**Goal**: avoid such `try/except` usage https://github.com/memory-cards/cards-exporter/blob/master/utils/cards.ts#L40 and give an ability read list of all known card-types

**To discuss**: if we need provide not only card-creator function, but also a validator function (might be useful if we're going add ability create cards from out interface) -- that's the reason why I have 

```  
choose_options: {
    card: cardIndex,
  },
```
instead of 
```
  choose_options: cardIndex,
```