### PR TITLE
Update <code> style & restrict uniqueId length

### DIFF
--- a/types/choose_sequence/index.js
+++ b/types/choose_sequence/index.js
@@ -173,6 +173,7 @@ module.exports = ({ card, tags }) => {
         width: 200px;
         margin-bottom: 5px;
         border-radius: 5px;
+        min-height: 2rem;
       }
 
       .guess {
@@ -212,6 +213,10 @@ module.exports = ({ card, tags }) => {
         font-size: 0.85rem;
         margin: 0;
         border: 1px solid #ccc;
+      }
+
+      pre code {
+        border-width: 0;
       }
 
       div pre {

--- a/utils/getUniqueId.js
+++ b/utils/getUniqueId.js
@@ -1,4 +1,5 @@
 module.exports = (prefix = 'xxx') =>
   Buffer.from(`${prefix}-${Date.now()}-${Math.random()}`)
     .toString('base64')
-    .replace(/[^a-zA-Z]/g, '');
+    .replace(/[^a-zA-Z]/g, '')
+    .substring(0, 30);


### PR DESCRIPTION
Remove border from `code` tag when it's in multiline code (see pictures):
Before this PR we had `id's` like this
```
<div id="PHASXMgYWgZWwdHkgYWxIGFdHJpYnVZSBjbzaWRlcmVkIGFwcHJvcHJpYXRlPzwvcDKPHByZTYkZSBjbGFzczibGFuZVhZUtaHRtbCIJiNMMaWnIHNyYziaWhZUucGnIiBhbHQIiICjwvYkZTLByZTKPHAPzPCwPgotMTUNDAyNDEyMTcOCwLjcwNjcwMzMyMTIxMjENDM_wrapper">
```
Pictures:
Before: 
![image](https://user-images.githubusercontent.com/32563455/55288393-b4483200-53bf-11e9-8b52-1a543f05c0ea.png)

After: 
![image](https://user-images.githubusercontent.com/32563455/55288376-66332e80-53bf-11e9-94c5-4b13b53c57dc.png)

Mobile view: 
![image](https://user-images.githubusercontent.com/32563455/55288381-7fd47600-53bf-11e9-98f1-2f60ade35825.png)

