### PR TITLE
update order-items card schema

### DIFF
--- a/types/order_items/README.md
+++ b/types/order_items/README.md
@@ -1,3 +1,5 @@
+<!-- @format -->
+
 # Choose options
 
 It should provide some description text and number of options. User have to sort options in proper order.
@@ -34,12 +36,22 @@ Should give a card with 5 sortable lines and button to check.
   card: {
     question: 'Order items to get a <b>SOLID</b>',
     answers: [
-      "a class should have only a single responsibility (i.e. changes to only one part of the software's specification should be able to affect the specification of the class)",
-      "software entities … should be open for extension, but closed for modification.",
-      "objects in a program should be replaceable with instances of their subtypes without altering the correctness of that program.",
-      "many client-specific interfaces are better than one general-purpose interface.",
-      'one should "depend upon abstractions, [not] concretions."'
-      ],
+      {
+        text: "a class should have only a single responsibility (i.e. changes to only one part of the software's specification should be able to affect the specification of the class)"
+      },
+      {
+        text: "software entities … should be open for extension, but closed for modification."
+      },
+      {
+        text: "objects in a program should be replaceable with instances of their subtypes without altering the correctness of that program."
+      },
+      {
+        text: "many client-specific interfaces are better than one general-purpose interface."
+      },
+      {
+        text: 'one should "depend upon abstractions, [not] concretions."'
+      }
+    ],
     comment: '<b>SOLID</b> is: <ol>\
     <li>Single responsibility principle</li>\
     <li>Open/closed principle</li>\

--- a/types/order_items/example.json5
+++ b/types/order_items/example.json5
@@ -5,11 +5,21 @@
   card: {
     question: "Order items to get a <b>SOLID</b>",
     answers: [
-      "a class should have only a single responsibility (i.e. changes to only one part of the software's specification should be able to affect the specification of the class)",
-      "software entities … should be open for extension, but closed for modification.",
-      "objects in a program should be replaceable with instances of their subtypes without altering the correctness of that program.",
-      "many client-specific interfaces are better than one general-purpose interface.",
-      'one should "depend upon abstractions, [not] concretions."'
+      {
+        text: "a class should have only a single responsibility (i.e. changes to only one part of the software's specification should be able to affect the specification of the class)"
+      },
+      {
+        text: "software entities … should be open for extension, but closed for modification."
+      },
+      {
+        text: "objects in a program should be replaceable with instances of their subtypes without altering the correctness of that program."
+      },
+      {
+        text: "many client-specific interfaces are better than one general-purpose interface."
+      },
+      {
+        text: 'one should "depend upon abstractions, [not] concretions."'
+      }
     ],
     comment: "<b>SOLID</b> is: <ol>\
     <li>Single responsibility principle</li>\

--- a/types/order_items/index.js
+++ b/types/order_items/index.js
@@ -74,7 +74,7 @@ module.exports = ({ card, tags }) => {
               + 'data-index="' + cardAnswers.indexOf(el) + '" '
               + 'ondragover="dragOver(event)" '
               + 'ondragstart="dragStart(event)">'
-              + el
+              + el.text
               + '</li>';
           })
           .join('');

--- a/types/order_items/json-schema.json
+++ b/types/order_items/json-schema.json
@@ -29,7 +29,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": "object",
+            "required": ["text"],
+            "properties": {
+              "text": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         },
         "comment": {


### PR DESCRIPTION
When I was working on creating a new card page, I've faced with the issue, when we have 4 types of the cards with different schema for **answer** field:
- **info** (no `answer` field);
- **choose_sequence**  -> `[{ text: string}]`;
- **choose_options**  -> `[{ text: string, correct?: true}]`;
- **order_items**  -> `[string]`;

So if I try to implement my logic in new page it will be messy because there will be a some useless in my point of view `if - else` sections to handle each card type differently. That's why I'd like to change `order_items` card type in that's why -> `[{ text: string}]`.

Does it suits you?
